### PR TITLE
Changed the add button location for create & edit class modals

### DIFF
--- a/code/WebApp/static/css/style.css
+++ b/code/WebApp/static/css/style.css
@@ -109,6 +109,9 @@ body {
     font-weight: bold;
 }
 
+.addRelationship, .addTextArea {
+    margin-bottom: 5px;
+}
 
 /* DISPLAY AREA */
 .flex-container {

--- a/code/WebApp/static/js/myscripts.js
+++ b/code/WebApp/static/js/myscripts.js
@@ -45,7 +45,7 @@ function classCardBtns() {
 
         // Preload the information we got into the appropriate textboxes of the edit Class Modal
 
-        alert("Edit class: #" + getId);
+        //alert("Edit class: #" + getId);
 
     });
 }
@@ -55,21 +55,19 @@ function createEditClassModalBtns() {
     // Adds a new text area for the fields and methods 
     $('.form-group').on('click', '.addTextArea', function() {
         var table = $(this).closest('.form-group');
-        table.append('<div class="input-group mb-3"><input type="text" class="form-control" placeholder="Enter name" aria-label="Name of field" aria-describedby="basic-addon2"><div class="input-group-append"><button class="btn btn-outline-secondary addTextArea" type="button"><i class="fas fa-plus"></i></button><button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button></div>');
+        table.append('<div class="input-group mb-3"><input type="text" class="form-control" placeholder="Enter name" aria-label="Name of field" aria-describedby="basic-addon2"><div class="input-group-append"><button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button></div>');
     });
 
     // Adds a new drop menu and text area for the relationships
     $('.form-group').on('click', '.addRelationship', function() {
         var table = $(this).closest('.form-group');
-        table.append('<div class="input-group mb-3"><select id="inputRelationship" class="form-control"><option selected>Choose type...</option><option>Aggregation</option><option>Composition</option><option>Inheritance</option><option>Generalization</option></select><input type="text" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2"><div class="input-group-append"><button class="btn btn-outline-secondary addRelationship" type="button"><i class="fas fa-plus"></i></button><button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button></div></div>');
+        table.append('<div class="input-group mb-3"><select id="inputRelationship" class="form-control"><option selected>Choose type...</option><option>Aggregation</option><option>Composition</option><option>Inheritance</option><option>Generalization</option></select><input type="text" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2"><div class="input-group-append"><button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button></div></div>');
     });
 
     // Deletes the fields, methods, or relationship text area that is no longer needed
     $('.form-group').on('click', '.delTextArea', function() {
         var table = $(this).closest('.form-group');
-        if (table.find('input:text').length > 1) {
-            $(this).closest('.input-group').remove();
-        }
+        $(this).closest('.input-group').remove();
     });
 
     // Displays new class card

--- a/code/WebApp/static/js/myscripts.js
+++ b/code/WebApp/static/js/myscripts.js
@@ -52,10 +52,17 @@ function classCardBtns() {
 
 // Functionality for the create class and edit class modal buttons
 function createEditClassModalBtns() {
-    // Adds a new text area for the fields and methods 
-    $('.form-group').on('click', '.addTextArea', function() {
+
+     // Adds a new text area for the fields
+     $('.form-group').on('click', '.addField', function() {
         var table = $(this).closest('.form-group');
-        table.append('<div class="input-group mb-3"><input type="text" class="form-control" placeholder="Enter name" aria-label="Name of field" aria-describedby="basic-addon2"><div class="input-group-append"><button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button></div>');
+        table.append('<div class="input-group mb-3"><input type="text" name="field_name" class="form-control" placeholder="Enter field name" aria-label="Name of field" aria-describedby="basic-addon2"><div class="input-group-append"><button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button></div>');
+    });
+
+    // Adds a new text area for the methods 
+    $('.form-group').on('click', '.addMethod', function() {
+        var table = $(this).closest('.form-group');
+        table.append('<div class="input-group mb-3"><input type="text" name="method_name" class="form-control" placeholder="Enter method name" aria-label="Name of field" aria-describedby="basic-addon2"><div class="input-group-append"><button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button></div>');
     });
 
     // Adds a new drop menu and text area for the relationships
@@ -68,11 +75,5 @@ function createEditClassModalBtns() {
     $('.form-group').on('click', '.delTextArea', function() {
         var table = $(this).closest('.form-group');
         $(this).closest('.input-group').remove();
-    });
-
-    // Displays new class card
-    $('#saveNewClass').click(function () {
-        $('#display').prepend('<div class="card shadow" id="cardId1"><div class="card-header">New Card</div><div class="card-body"><ul class="list-group list-group-flush" id="fieldName"><li>Field 1</li></ul></div><div class="card-body"><ul class="list-group list-group-flush"><li>Method 1</li></ul></div><div class="card-body"><ul class="list-group list-group-flush"><li>Relationship <i class="fas fa-long-arrow-alt-right"></i> Class 2</li></ul></div><div class="card-footer nav justify-content-end nav-pills "><button type="button" class="btn btn-primary getID editCard" data-toggle="modal" data-target="#editClassModal"><i class="fas fa-edit"></i></button><button type="button" class="btn btn-primary getID" data-toggle="modal" data-target="#deleteModal"><i class="fas fa-trash-alt"></i></button></div></div>');
-        $("#createClassModal").modal('hide');
     });
 }

--- a/code/WebApp/templates/createClassModal.html
+++ b/code/WebApp/templates/createClassModal.html
@@ -6,12 +6,12 @@
                 <h4 class="modal-title w-100" id="myModalLabel">Create a new class</h4>
             </div>
             <div class="modal-body">
-                <form>
+                <form id="createClassModalForm" action="{{url_for('createClass')}}" method="POST">
                     <!-- class name START -->
                     <div class="form-group">
                         <label for="classname">Class Name</label>
                         <div class="input-group mb-3">
-                            <input type="text" class="form-control" placeholder="Enter class name" aria-label="Name of class" aria-describedby="basic-addon2">
+                            <input type="text" name="class_name" class="form-control" placeholder="Enter class name" aria-label="Name of class" aria-describedby="basic-addon2">
                         </div>
                     </div>
                     <!-- class name END -->
@@ -19,9 +19,9 @@
                     <!-- fields START -->
                     <div class="form-group">
                         <label for="fieldname">Fields</label>
-                        <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Field</button>
+                        <button class="btn btn-outline-secondary btn-sm float-right addField" type="button">Add Field</button>
                         <div class="input-group mb-3">
-                            <input type="text" class="form-control" placeholder="Enter field name" aria-label="Name of field" aria-describedby="basic-addon2">
+                            <input type="text" name="field_name" class="form-control" placeholder="Enter field name" aria-label="Name of field" aria-describedby="basic-addon2">
                             <div class="input-group-append">
                                 <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                             </div>
@@ -32,9 +32,9 @@
                     <!-- methods START -->
                     <div class="form-group">
                         <label for="methodname">Methods</label>
-                        <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Method</button>
+                        <button class="btn btn-outline-secondary btn-sm float-right addMethod" type="button">Add Method</button>
                         <div class="input-group mb-3">
-                            <input type="text" class="form-control" placeholder="Enter method name" aria-label="Name of method" aria-describedby="basic-addon2">
+                            <input type="text" name="method_name" class="form-control" placeholder="Enter method name" aria-label="Name of method" aria-describedby="basic-addon2">
                             <div class="input-group-append">
                                 <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                             </div>
@@ -47,14 +47,14 @@
                         <label for="relationship">Relationships</label>
                         <button class="btn btn-outline-secondary btn-sm float-right addRelationship" type="button">Add Relationship</button>
                         <div class="input-group mb-3">
-                            <select id="inputRelationship" class="form-control">
+                            <select id="inputRelationship" name="relationship_type" class="form-control">
                                 <option selected>Choose type...</option>
                                 <option>Aggregation</option>
                                 <option>Composition</option>
                                 <option>Inheritance</option>
                                 <option>Generalization</option>
                             </select>
-                            <input type="text" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2">
+                            <input type="text" name="relationship_other" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2">
                             <div class="input-group-append">
                                 <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                             </div>
@@ -65,7 +65,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-primary btn-sm" id="saveNewClass">Save</button>
+                <button type="submit" form="createClassModalForm" class="btn btn-primary btn-sm" id="saveNewClass">Save</button>
             </div>
         </div>
     </div>

--- a/code/WebApp/templates/createClassModal.html
+++ b/code/WebApp/templates/createClassModal.html
@@ -19,10 +19,10 @@
                     <!-- fields START -->
                     <div class="form-group">
                         <label for="fieldname">Fields</label>
+                        <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Field</button>
                         <div class="input-group mb-3">
                             <input type="text" class="form-control" placeholder="Enter field name" aria-label="Name of field" aria-describedby="basic-addon2">
                             <div class="input-group-append">
-                                <button class="btn btn-outline-secondary addTextArea" type="button"><i class="fas fa-plus"></i></button>
                                 <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                             </div>
                         </div>
@@ -32,10 +32,10 @@
                     <!-- methods START -->
                     <div class="form-group">
                         <label for="methodname">Methods</label>
+                        <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Method</button>
                         <div class="input-group mb-3">
                             <input type="text" class="form-control" placeholder="Enter method name" aria-label="Name of method" aria-describedby="basic-addon2">
                             <div class="input-group-append">
-                                <button class="btn btn-outline-secondary addTextArea" type="button"><i class="fas fa-plus"></i></button>
                                 <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                             </div>
                         </div>
@@ -45,6 +45,7 @@
                     <!-- relationships START -->
                     <div class="form-group">
                         <label for="relationship">Relationships</label>
+                        <button class="btn btn-outline-secondary btn-sm float-right addRelationship" type="button">Add Relationship</button>
                         <div class="input-group mb-3">
                             <select id="inputRelationship" class="form-control">
                                 <option selected>Choose type...</option>
@@ -55,7 +56,6 @@
                             </select>
                             <input type="text" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2">
                             <div class="input-group-append">
-                                <button class="btn btn-outline-secondary addRelationship" type="button"><i class="fas fa-plus"></i></button>
                                 <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                             </div>
                         </div>

--- a/code/WebApp/templates/editClassModal.html
+++ b/code/WebApp/templates/editClassModal.html
@@ -11,7 +11,7 @@
                             <div class="form-group">
                                 <label for="classname">Class Name</label>
                                 <div class="input-group mb-3">
-                                    <input type="text" class="form-control" placeholder="...preloaded class name..." aria-label="Name of class" aria-describedby="basic-addon2">
+                                    <input type="text" name="class_name" class="form-control" placeholder="...preloaded class name..." aria-label="Name of class" aria-describedby="basic-addon2">
                                 </div>
                             </div>
                             <!-- class name END -->
@@ -19,9 +19,9 @@
                             <!-- fields START -->
                             <div class="form-group">
                                 <label for="fieldname">Fields</label>
-                                <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Field</button>
+                                <button class="btn btn-outline-secondary btn-sm float-right addField" type="button">Add Field</button>
                                 <div class="input-group mb-3">
-                                    <input type="text" class="form-control" placeholder="...preloaded field name..." aria-label="Name of field" aria-describedby="basic-addon2">
+                                    <input type="text" name="field_name" class="form-control" placeholder="...preloaded field name..." aria-label="Name of field" aria-describedby="basic-addon2">
                                     <div class="input-group-append">
                                         <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                                     </div>
@@ -32,9 +32,9 @@
                             <!-- methods START -->
                             <div class="form-group">
                                 <label for="methodname">Methods</label>
-                                <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Method</button>
+                                <button class="btn btn-outline-secondary btn-sm float-right addMethod" type="button">Add Method</button>
                                 <div class="input-group mb-3">
-                                    <input type="text" class="form-control" placeholder="...preloaded method name..." aria-label="Name of method" aria-describedby="basic-addon2">
+                                    <input type="text" name="method_name" class="form-control" placeholder="...preloaded method name..." aria-label="Name of method" aria-describedby="basic-addon2">
                                     <div class="input-group-append">
                                         <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                                     </div>
@@ -54,7 +54,7 @@
                                         <option>Inheritance</option>
                                         <option>Generalization</option>
                                     </select>
-                                    <input type="text" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2">
+                                    <input type="text" name="relationship_other" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2">
                                     <div class="input-group-append">
                                         <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                                     </div>

--- a/code/WebApp/templates/editClassModal.html
+++ b/code/WebApp/templates/editClassModal.html
@@ -19,10 +19,10 @@
                             <!-- fields START -->
                             <div class="form-group">
                                 <label for="fieldname">Fields</label>
+                                <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Field</button>
                                 <div class="input-group mb-3">
                                     <input type="text" class="form-control" placeholder="...preloaded field name..." aria-label="Name of field" aria-describedby="basic-addon2">
                                     <div class="input-group-append">
-                                        <button class="btn btn-outline-secondary addTextArea" type="button"><i class="fas fa-plus"></i></button>
                                         <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                                     </div>
                                 </div>
@@ -32,10 +32,10 @@
                             <!-- methods START -->
                             <div class="form-group">
                                 <label for="methodname">Methods</label>
+                                <button class="btn btn-outline-secondary btn-sm float-right addTextArea" type="button">Add Method</button>
                                 <div class="input-group mb-3">
                                     <input type="text" class="form-control" placeholder="...preloaded method name..." aria-label="Name of method" aria-describedby="basic-addon2">
                                     <div class="input-group-append">
-                                        <button class="btn btn-outline-secondary addTextArea" type="button"><i class="fas fa-plus"></i></button>
                                         <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                                     </div>
                                 </div>
@@ -45,6 +45,7 @@
                             <!-- relationships START -->
                             <div class="form-group">
                                 <label for="relationship">Relationships</label>
+                                <button class="btn btn-outline-secondary btn-sm float-right addRelationship" type="button">Add Relationship</button>
                                 <div class="input-group mb-3">
                                     <select id="inputRelationship" class="form-control">
                                         <option selected>Choose type...</option>
@@ -55,7 +56,6 @@
                                     </select>
                                     <input type="text" class="form-control" placeholder="Enter associated class name" aria-label="Associated class" aria-describedby="basic-addon2">
                                     <div class="input-group-append">
-                                        <button class="btn btn-outline-secondary addRelationship" type="button"><i class="fas fa-plus"></i></button>
                                         <button class="btn btn-outline-secondary delTextArea" type="button"><i class="fas fa-minus"></i></button>
                                     </div>
                                 </div>


### PR DESCRIPTION
This is where I moved the add buttons:
![Screenshot (25)](https://user-images.githubusercontent.com/20378033/95373742-6ad97c80-08ab-11eb-9611-07bd88505046.png)

We are now able to completely delete all text areas:
![Screenshot (26)](https://user-images.githubusercontent.com/20378033/95373924-ab38fa80-08ab-11eb-8e8f-8042cb2c9186.png)
